### PR TITLE
Opción de correo UC dirige directamente a gmail

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -376,7 +376,7 @@ var directUC = (function () {
 
   self.openMail = function (_user, _pass) {
 
-    var url = 'http://webaccess.uc.cl';
+    var url = 'https://mail.google.com/a/uc.cl';
     localStorage.setItem('mailuc-redirect', 1);
 
     if (optionSameTab() === true) {


### PR DESCRIPTION
#10
Probé la extensión solo en el caso de tener la sección abierta.
Sin la extención, el nuevo link se dirige a [sso.uc.cl](https://sso.uc.cl), por lo que debería funcionar en el caso contrario.