### PR TITLE
fix: remove incognito key

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "version": "0.3.24",
   "manifest_version": 2,
   "author": "wachunei",
-  "incognito": "split",
+  "incognito": "not_allowed",
   "icons": {
     "16": "i/icon_48.png",
     "48": "i/icon_48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,6 @@
   "version": "0.3.24",
   "manifest_version": 2,
   "author": "wachunei",
-  "incognito": "not_allowed",
   "icons": {
     "16": "i/icon_48.png",
     "48": "i/icon_48.png",


### PR DESCRIPTION
The `split` option for incognito **is [not](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/incognito) supported in Firefox** and it's completely unnecessary in Chrome anyway. 

Set to `split`, it allowed for two simultaneous (and independent) copies of the extension to be ran when incognito was used in Chromium and derivatives. Even though this might have benefited testing, Chrome's developer tools and Mozilla's web-ext work much better for this purpose.

I changed `split` to `not_allowed`, disabling incognito completely. I seriously doubt anyone has the intention to use UC's services on incognito. (And even if that was the case, they would have to log in manually each time, so another pain in the ass)

**Allows successful verification in the [Web Extension Test](https://www.extensiontest.com/).**