### PR TITLE
Add resolution for node-forge@0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
     "webext-redux": "^2.1.7",
     "webextension-polyfill": "^0.6.0"
   },
+  "resolutions": {
+    "node-forge": "0.10.0"
+  },
   "jest": {
     "testMatch": [
       "**/__tests__/**/?(*.)+(spec|test).[jt]s?(x)",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6642,15 +6642,10 @@ node-fetch@^2.6.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-forge@^0.10.0:
+node-forge@0.10.0, node-forge@^0.10.0, node-forge@^0.7.1:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
-
-node-forge@^0.7.1:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
-  integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Adding a selective dependency resolution for node-forge@0.10.0 because of security alert CVE-2020-7720, although it does not affect this codebase, is a [parcel v1 dependency which is not going to be upgraded anymore](https://github.com/parcel-bundler/parcel/issues/5145#issuecomment-693228935). Until upgrading to parcel v2 this resolution will remain.