### PR TITLE
refactor: update gh-actions deprecating

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                 path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,13 +5,13 @@ jobs:
         runs-on: ubuntu-latest
         name: lint
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2-beta
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                 node-version: '14'
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               id: yarn-cache
               with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -9,13 +9,13 @@ jobs:
         runs-on: ubuntu-latest
         name: lint
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2-beta
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                 node-version: '14'
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               id: yarn-cache
               with:
@@ -32,13 +32,13 @@ jobs:
         runs-on: ubuntu-latest
         name: test
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2-beta
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                 node-version: '14'
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               id: yarn-cache
               with:
@@ -58,13 +58,13 @@ jobs:
               target: ['firefox', 'chrome']
         name: build
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2-beta
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                 node-version: '14'
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               id: yarn-cache
               with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                 path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -39,7 +39,7 @@ jobs:
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                 path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -65,7 +65,7 @@ jobs:
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                 path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,11 +83,7 @@ jobs:
             - name: Get Release Changelog
               id: get-release-changelog
               run: |
-                text="$(yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})"
-                text="${text//'%'/'%25'}"
-                text="${text//$'\n'/'%0A'}"
-                text="${text//$'\r'/'%0D'}"
-                echo "changelog=$text" >> $GITHUB_OUTPUT
+                echo "changelog=$(yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})" >> $GITHUB_OUTPUT
             - name: Print Release Changelog
               run: echo "${{ steps.get-release-changelog.outputs.changelog }}"
             - name: Create Draft Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
               run: |
                 text="$(yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})"
                 text="${text//'%'/'%25'}"
+                text="${text//$'\n'/'%0A'}"
                 text="${text//$'\r'/'%0D'}"
                 echo "changelog=$text" >> $GITHUB_OUTPUT
             - name: Print Release Changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ jobs:
         runs-on: ubuntu-latest
         name: lint
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2-beta
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                 node-version: '14'
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               id: yarn-cache
               with:
@@ -31,13 +31,13 @@ jobs:
         runs-on: ubuntu-latest
         name: test
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2-beta
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                 node-version: '14'
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               id: yarn-cache
               with:
@@ -54,15 +54,15 @@ jobs:
         needs: test
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                 fetch-depth: 0
-            - uses: actions/setup-node@v2-beta
+            - uses: actions/setup-node@v3
               with:
                 node-version: '14'
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               id: yarn-cache
               with:
@@ -74,12 +74,12 @@ jobs:
               run: yarn --frozen-lockfile
             - name: Get the version
               id: get-version
-              run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+              run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
             - name: Get the version number
               id: get-version-number
               run: |
                 version=${{ steps.get-version.outputs.version}}
-                echo ::set-output name=number::${version:1}
+                echo "number=${version:1}" >> $GITHUB_OUTPUT
             - name: Get Release Changelog
               id: get-release-changelog
               run: |
@@ -87,7 +87,7 @@ jobs:
                 text="${text//'%'/'%25'}"
                 text="${text//$'\n'/'%0A'}"
                 text="${text//$'\r'/'%0D'}"
-                echo "::set-output name=changelog::$text"
+                echo "changelog=$text" >> $GITHUB_OUTPUT
             - name: Print Release Changelog
               run: echo "${{ steps.get-release-changelog.outputs.changelog }}"
             - name: Create Draft Release
@@ -123,13 +123,13 @@ jobs:
               target: ['firefox', 'chrome']
         name: pack
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2-beta
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                 node-version: '14'
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               id: yarn-cache
               with:
@@ -150,8 +150,8 @@ jobs:
             - name: Create Artifacts outputs
               id: artifacts
               run: |
-                echo "::set-output name=version::$(cat version.txt)"
-                echo "::set-output name=upload_url::$(cat upload_url.txt)"
+                echo "version=$(cat version.txt)" >> $GITHUB_OUTPUT
+                echo "upload_url=$(cat upload_url.txt)" >> $GITHUB_OUTPUT
             - name: Upload Release Asset (${{ matrix.target}})
               id: upload-release-asset
               uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
               id: get-release-changelog
               run: |
                 text="$(yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})"
+                text="${text//'%'/'%25'}"
                 echo "changelog=$text" >> $GITHUB_OUTPUT
             - name: Print Release Changelog
               run: echo "${{ steps.get-release-changelog.outputs.changelog }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,10 +83,7 @@ jobs:
             - name: Get Release Changelog
               id: get-release-changelog
               run: |
-                text="$(yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})"
-                text="${text//'%'/'%25'}"
-                text="${text//$'\n'/'%0A'}"
-                text="${text//$'\r'/'%0D'}"
+                text="$(cat << yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})"
                 echo "changelog=$text" >> $GITHUB_OUTPUT
             - name: Print Release Changelog
               run: echo "${{ steps.get-release-changelog.outputs.changelog }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
               run: |
                 text="$(yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})"
                 text="${text//'%'/'%25'}"
+                text="${text//$'\r'/'%0D'}"
                 echo "changelog=$text" >> $GITHUB_OUTPUT
             - name: Print Release Changelog
               run: echo "${{ steps.get-release-changelog.outputs.changelog }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
             - name: Get Release Changelog
               id: get-release-changelog
               run: |
-                text="$(cat << yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})"
+                text="$(cat yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})"
                 echo "changelog=$text" >> $GITHUB_OUTPUT
             - name: Print Release Changelog
               run: echo "${{ steps.get-release-changelog.outputs.changelog }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,8 @@ jobs:
             - name: Get Release Changelog
               id: get-release-changelog
               run: |
-                echo "changelog=$(yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})" >> $GITHUB_OUTPUT
+                text="$(yarn run --silent changelog:release --starting-version ${{ steps.get-version.outputs.version }})"
+                echo "changelog=$text" >> $GITHUB_OUTPUT
             - name: Print Release Changelog
               run: echo "${{ steps.get-release-changelog.outputs.changelog }}"
             - name: Create Draft Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                 path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -38,7 +38,7 @@ jobs:
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                 path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -63,7 +63,7 @@ jobs:
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                 path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -130,7 +130,7 @@ jobs:
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                 path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
+### [v4.2.4](https://github.com/Baelfire18/directUC/compare/v4.2.3...v4.2.4)
+
+- update changelog action v3 [`fb8a508`](https://github.com/Baelfire18/directUC/commit/fb8a508752ada714d85d6bc17fc4e9cf1c1c5563)
+
 ### [v4.2.3](https://github.com/Baelfire18/directUC/compare/v4.2.2...v4.2.3)
+
+> 14 November 2022
 
 - update changelog action v2 [`b43530e`](https://github.com/Baelfire18/directUC/commit/b43530eaff7437379d4afcd39aaa0d9a04b60757)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
+### [v4.2.2](https://github.com/Baelfire18/directUC/compare/v4.2.1...v4.2.2)
+
+- update changelog action [`d051f8d`](https://github.com/Baelfire18/directUC/commit/d051f8da37fa625b4561fb7c0f5949634e51d114)
+
 ### [v4.2.1](https://github.com/Baelfire18/directUC/compare/v4.2.0...v4.2.1)
+
+> 14 November 2022
 
 ### v4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Changelog
 
-### 4.2.0
+### [v4.2.1](https://github.com/Baelfire18/directUC/compare/v4.2.0...v4.2.1)
+
+### v4.2.0
+
+> 14 November 2022
 
 - Update for new SSO page structure [`#619`](https://github.com/Baelfire18/directUC/pull/619)
 - Upgrade dependencies (aug 22) [`#598`](https://github.com/Baelfire18/directUC/pull/598)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
+### [v4.2.3](https://github.com/Baelfire18/directUC/compare/v4.2.2...v4.2.3)
+
+- update changelog action v2 [`b43530e`](https://github.com/Baelfire18/directUC/commit/b43530eaff7437379d4afcd39aaa0d9a04b60757)
+
 ### [v4.2.2](https://github.com/Baelfire18/directUC/compare/v4.2.1...v4.2.2)
+
+> 14 November 2022
 
 - update changelog action [`d051f8d`](https://github.com/Baelfire18/directUC/commit/d051f8da37fa625b4561fb7c0f5949634e51d114)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
+### [v4.2.6](https://github.com/Baelfire18/directUC/compare/v4.2.5...v4.2.6)
+
+- update changelog action v5 xd [`afaf8c6`](https://github.com/Baelfire18/directUC/commit/afaf8c6de0713d107f39bdaf334eeddffe6a58e3)
+
 ### [v4.2.5](https://github.com/Baelfire18/directUC/compare/v4.2.4...v4.2.5)
+
+> 14 November 2022
 
 - update changelog action v4 [`df77649`](https://github.com/Baelfire18/directUC/commit/df776499979d5bc87ceb0a7a7af9ac2476790394)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
+### [v4.2.5](https://github.com/Baelfire18/directUC/compare/v4.2.4...v4.2.5)
+
+- update changelog action v4 [`df77649`](https://github.com/Baelfire18/directUC/commit/df776499979d5bc87ceb0a7a7af9ac2476790394)
+
 ### [v4.2.4](https://github.com/Baelfire18/directUC/compare/v4.2.3...v4.2.4)
+
+> 14 November 2022
 
 - update changelog action v3 [`fb8a508`](https://github.com/Baelfire18/directUC/commit/fb8a508752ada714d85d6bc17fc4e9cf1c1c5563)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,210 +1,77 @@
 ## Changelog
 
-### [v1.3.1](https://github.com/wachunei/directUC/compare/v1.3.0...v1.3.1)
-
-- Update for new SSO page structure [`#619`](https://github.com/wachunei/directUC/pull/619)
-- Upgrade dependencies (aug 22) [`#598`](https://github.com/wachunei/directUC/pull/598)
-
-### [v1.3.0](https://github.com/wachunei/directUC/compare/v1.2.0...v1.3.0)
-
-> 6 December 2021
-
-- Add custom primary color feature [`#549`](https://github.com/wachunei/directUC/pull/549)
-- Upgrade dependencies [`#498`](https://github.com/wachunei/directUC/pull/498)
-
-### [v1.2.0](https://github.com/wachunei/directUC/compare/v1.1.3...v1.2.0)
-
-> 20 June 2021
-
-- Use ssocas as service for logging in [`#404`](https://github.com/wachunei/directUC/pull/404)
-
-### [v1.1.3](https://github.com/wachunei/directUC/compare/v1.1.2...v1.1.3)
-
-> 17 June 2021
-
-- Open options page when not logged in [`#400`](https://github.com/wachunei/directUC/pull/400)
-
-### [v1.1.2](https://github.com/wachunei/directUC/compare/v1.1.1...v1.1.2)
-
-> 2 June 2021
-
-- 🏳️‍🌈 Add pride icon [`#365`](https://github.com/wachunei/directUC/pull/365)
-
-### [v1.1.1](https://github.com/wachunei/directUC/compare/v1.1.0...v1.1.1)
-
-> 24 May 2021
-
-- Fix changelog ignore [`#350`](https://github.com/wachunei/directUC/pull/350)
-- Ignore dependabot merges on changelog [`#349`](https://github.com/wachunei/directUC/pull/349)
-- v1.1.0: Use parcel v2 [`#276`](https://github.com/wachunei/directUC/pull/276)
-
-### [v1.1.0](https://github.com/wachunei/directUC/compare/v1.0.18...v1.1.0)
-
-> 25 April 2021
-
-- Bump react, react-dom and react-test-renderer [`#248`](https://github.com/wachunei/directUC/pull/248)
-- Upgrade husky to v5 [`#226`](https://github.com/wachunei/directUC/pull/226)
-- Use parcel v2 [`5c68678`](https://github.com/wachunei/directUC/commit/5c68678e4bc0561cbe1576d4ade5777bc288ab5b)
-
-### [v1.0.18](https://github.com/wachunei/directUC/compare/v1.0.17...v1.0.18)
-
-> 11 December 2020
-
-- Create FUNDING.yml [`#183`](https://github.com/wachunei/directUC/pull/183)
-- Use node 14 for development [`#170`](https://github.com/wachunei/directUC/pull/170)
-- Refactor README [`#150`](https://github.com/wachunei/directUC/pull/150)
-- Fix Firefox Addon big badge [`43600a8`](https://github.com/wachunei/directUC/commit/43600a8a33a572f8a085567a44cebd0af4f26241)
-
-### [v1.0.17](https://github.com/wachunei/directUC/compare/v1.0.16...v1.0.17)
-
-> 5 November 2020
-
-- Add analytics extra app data [`#149`](https://github.com/wachunei/directUC/pull/149)
-- Bump react, react-dom and react-test-renderer [`#129`](https://github.com/wachunei/directUC/pull/129)
-- Upgrade react-test-renderer to v17 [`#126`](https://github.com/wachunei/directUC/pull/126)
-- ⚛️ Upgrade to React 17 [`#85`](https://github.com/wachunei/directUC/pull/85)
-- Remove `setupTests.js` [`#122`](https://github.com/wachunei/directUC/pull/122)
-- Reorder services [`#121`](https://github.com/wachunei/directUC/pull/121)
-- Use testing library and add useForm hook tests [`#116`](https://github.com/wachunei/directUC/pull/116)
-- Add eslint-plugin-react-hooks and fix warnings [`#115`](https://github.com/wachunei/directUC/pull/115)
-
-### [v1.0.16](https://github.com/wachunei/directUC/compare/v1.0.15...v1.0.16)
-
-> 19 October 2020
-
-- Add resolution for node-forge@0.10.0 [`#114`](https://github.com/wachunei/directUC/pull/114)
-- Upgrade react-dom react-test-renderer [`#105`](https://github.com/wachunei/directUC/pull/105)
-- ⚙️ Use New JSX Transform [`#104`](https://github.com/wachunei/directUC/pull/104)
-- Upgrade dependencies [`#94`](https://github.com/wachunei/directUC/pull/94)
-- Refactor manifest generate.js script + tests [`#91`](https://github.com/wachunei/directUC/pull/91)
-- Add analytics extra app data [`#90`](https://github.com/wachunei/directUC/pull/90)
-
-### [v1.0.15](https://github.com/wachunei/directUC/compare/v1.0.14...v1.0.15)
-
-> 2 October 2020
-
-- Add services to omnibox according to settings [`#89`](https://github.com/wachunei/directUC/pull/89)
-- Use babel package.json config [`#88`](https://github.com/wachunei/directUC/pull/88)
-- Update babel config [`#86`](https://github.com/wachunei/directUC/pull/86)
-
-### [v1.0.14](https://github.com/wachunei/directUC/compare/v1.0.13...v1.0.14)
-
-> 28 September 2020
-
-- Add Google Drive service [`#84`](https://github.com/wachunei/directUC/pull/84)
-
-### [v1.0.13](https://github.com/wachunei/directUC/compare/v1.0.12...v1.0.13)
-
-> 18 September 2020
-
-- Add Drag Handler and About section [`#74`](https://github.com/wachunei/directUC/pull/74)
-
-### [v1.0.12](https://github.com/wachunei/directUC/compare/v1.0.11...v1.0.12)
-
-> 17 September 2020
-
-- Fix keeping always at least one service displayed in popup [`#73`](https://github.com/wachunei/directUC/pull/73)
-- Add services sorting using drag and drop [`#72`](https://github.com/wachunei/directUC/pull/72)
-- Avoid accidentally burning your eyes when disabling auto dark mode [`#69`](https://github.com/wachunei/directUC/pull/69)
-- Revert "v1.0.12" [`b0c7a31`](https://github.com/wachunei/directUC/commit/b0c7a31f8e9b19b65a7beb372a5d301f32ec5f5f)
-
-### [v1.0.11](https://github.com/wachunei/directUC/compare/v1.0.10...v1.0.11)
-
-> 11 September 2020
-
-- 📦✨ Add releases packed artifacts [`#66`](https://github.com/wachunei/directUC/pull/66)
-
-### [v1.0.10](https://github.com/wachunei/directUC/compare/v1.0.8...v1.0.10)
-
-> 11 September 2020
-
-- Disable analytics for Firefox [`#63`](https://github.com/wachunei/directUC/pull/63)
-
-### [v1.0.8](https://github.com/wachunei/directUC/compare/v1.0.7...v1.0.8)
-
-> 10 September 2020
-
-- Use titleCase false in react-ga [`#62`](https://github.com/wachunei/directUC/pull/62)
-
-### [v1.0.7](https://github.com/wachunei/directUC/compare/v1.0.6...v1.0.7)
-
-> 9 September 2020
-
-- Refactor Analytics and add policies checkbox [`#61`](https://github.com/wachunei/directUC/pull/61)
-
-### [v1.0.6](https://github.com/wachunei/directUC/compare/v1.0.5...v1.0.6)
-
-> 7 September 2020
-
-- feat: Add modifier click to open service in background new tab [`#59`](https://github.com/wachunei/directUC/pull/59)
-
-### [v1.0.5](https://github.com/wachunei/directUC/compare/v1.0.4...v1.0.5)
-
-> 27 August 2020
-
-- Fix service name analytics [`#50`](https://github.com/wachunei/directUC/pull/50)
-
-### [v1.0.4](https://github.com/wachunei/directUC/compare/v1.0.3...v1.0.4)
-
-> 26 August 2020
-
-- fix: Make analytics work again [`#49`](https://github.com/wachunei/directUC/pull/49)
-- Upgrade dependencies [`#41`](https://github.com/wachunei/directUC/pull/41)
-- Create dependabot.yml [`#35`](https://github.com/wachunei/directUC/pull/35)
-
-### [v1.0.3](https://github.com/wachunei/directUC/compare/v1.0.2...v1.0.3)
-
-> 16 August 2020
-
-- Restore previous analytics setup [`#34`](https://github.com/wachunei/directUC/pull/34)
-- Add middleclick support for service button [`#33`](https://github.com/wachunei/directUC/pull/33)
-- Use node version 12 [`#30`](https://github.com/wachunei/directUC/pull/30)
-- Add Privacy Policy and Terms & Conditions [`#29`](https://github.com/wachunei/directUC/pull/29)
-- Get the version name to generate release changelog [`#28`](https://github.com/wachunei/directUC/pull/28)
-
-### [v1.0.2](https://github.com/wachunei/directUC/compare/v1.0.1...v1.0.2)
-
-> 9 August 2020
-
-- Add Dark Mode [`#27`](https://github.com/wachunei/directUC/pull/27)
-- Add release action. Add develop branch checks [`#26`](https://github.com/wachunei/directUC/pull/26)
-- 📝 Changelog Templates [`#24`](https://github.com/wachunei/directUC/pull/24)
-- Add tests and initial github actions [`#23`](https://github.com/wachunei/directUC/pull/23)
-- Add missing reducers test [`#22`](https://github.com/wachunei/directUC/pull/22)
-- Add LICENSE [`#21`](https://github.com/wachunei/directUC/pull/21)
-- Add auto-changelog [`#20`](https://github.com/wachunei/directUC/pull/20)
-
-### [v1.0.1](https://github.com/wachunei/directUC/compare/v1.0.0...v1.0.1)
-
-> 7 August 2020
-
-- Use package.json version [`#18`](https://github.com/wachunei/directUC/pull/18)
-- Add mailuc service [`#17`](https://github.com/wachunei/directUC/pull/17)
-
-## [v1.0.0](https://github.com/wachunei/directUC/compare/v0.3.24...v1.0.0)
-
-> 6 August 2020
-
-- v1.0.0 - New version ✨ [`#14`](https://github.com/wachunei/directUC/pull/14)
-- fix: remove incognito key [`#13`](https://github.com/wachunei/directUC/pull/13)
-- fix: can't login directly to portal uc #4 [`#12`](https://github.com/wachunei/directUC/pull/12)
-- Email goes directly to gmail [`#11`](https://github.com/wachunei/directUC/pull/11)
-
-### [v0.3.24](https://github.com/wachunei/directUC/compare/v0.3.23...v0.3.24)
-
-> 9 June 2020
-
-- Arreglar DCConfesión 9134 [`#9`](https://github.com/wachunei/directUC/pull/9)
-
-### v0.3.23
-
-> 5 June 2020
-
-- Add suport to the Canvas platform. Small fixes. [`#3`](https://github.com/wachunei/directUC/pull/3)
-- Add LICENSE [`#5`](https://github.com/wachunei/directUC/pull/5)
-- Version 0.1.5 [`c0eed7d`](https://github.com/wachunei/directUC/commit/c0eed7dbaf9f517171e17238b8835cd0a4b91d66)
-- Major rewrite 2.0 [`337a1fd`](https://github.com/wachunei/directUC/commit/337a1fd709bc807d927ff4f6fded81f3fbc2d877)
-- Major Rewrite [`b3a5c83`](https://github.com/wachunei/directUC/commit/b3a5c8371e877b3520e509708cbd788df85775fc)
+### 4.2.0
+
+- Update for new SSO page structure [`#619`](https://github.com/Baelfire18/directUC/pull/619)
+- Upgrade dependencies (aug 22) [`#598`](https://github.com/Baelfire18/directUC/pull/598)
+- Add custom primary color feature [`#549`](https://github.com/Baelfire18/directUC/pull/549)
+- Upgrade dependencies [`#498`](https://github.com/Baelfire18/directUC/pull/498)
+- Use ssocas as service for logging in [`#404`](https://github.com/Baelfire18/directUC/pull/404)
+- Open options page when not logged in [`#400`](https://github.com/Baelfire18/directUC/pull/400)
+- 🏳️‍🌈 Add pride icon [`#365`](https://github.com/Baelfire18/directUC/pull/365)
+- Fix changelog ignore [`#350`](https://github.com/Baelfire18/directUC/pull/350)
+- Ignore dependabot merges on changelog [`#349`](https://github.com/Baelfire18/directUC/pull/349)
+- v1.1.0: Use parcel v2 [`#276`](https://github.com/Baelfire18/directUC/pull/276)
+- Bump react, react-dom and react-test-renderer [`#248`](https://github.com/Baelfire18/directUC/pull/248)
+- Upgrade husky to v5 [`#226`](https://github.com/Baelfire18/directUC/pull/226)
+- Create FUNDING.yml [`#183`](https://github.com/Baelfire18/directUC/pull/183)
+- Use node 14 for development [`#170`](https://github.com/Baelfire18/directUC/pull/170)
+- Refactor README [`#150`](https://github.com/Baelfire18/directUC/pull/150)
+- Add analytics extra app data [`#149`](https://github.com/Baelfire18/directUC/pull/149)
+- Bump react, react-dom and react-test-renderer [`#129`](https://github.com/Baelfire18/directUC/pull/129)
+- Upgrade react-test-renderer to v17 [`#126`](https://github.com/Baelfire18/directUC/pull/126)
+- ⚛️ Upgrade to React 17 [`#85`](https://github.com/Baelfire18/directUC/pull/85)
+- Remove `setupTests.js` [`#122`](https://github.com/Baelfire18/directUC/pull/122)
+- Reorder services [`#121`](https://github.com/Baelfire18/directUC/pull/121)
+- Use testing library and add useForm hook tests [`#116`](https://github.com/Baelfire18/directUC/pull/116)
+- Add eslint-plugin-react-hooks and fix warnings [`#115`](https://github.com/Baelfire18/directUC/pull/115)
+- Add resolution for node-forge@0.10.0 [`#114`](https://github.com/Baelfire18/directUC/pull/114)
+- Upgrade react-dom react-test-renderer [`#105`](https://github.com/Baelfire18/directUC/pull/105)
+- ⚙️ Use New JSX Transform [`#104`](https://github.com/Baelfire18/directUC/pull/104)
+- Upgrade dependencies [`#94`](https://github.com/Baelfire18/directUC/pull/94)
+- Refactor manifest generate.js script + tests [`#91`](https://github.com/Baelfire18/directUC/pull/91)
+- Add analytics extra app data [`#90`](https://github.com/Baelfire18/directUC/pull/90)
+- Add services to omnibox according to settings [`#89`](https://github.com/Baelfire18/directUC/pull/89)
+- Use babel package.json config [`#88`](https://github.com/Baelfire18/directUC/pull/88)
+- Update babel config [`#86`](https://github.com/Baelfire18/directUC/pull/86)
+- Add Google Drive service [`#84`](https://github.com/Baelfire18/directUC/pull/84)
+- Add Drag Handler and About section [`#74`](https://github.com/Baelfire18/directUC/pull/74)
+- Fix keeping always at least one service displayed in popup [`#73`](https://github.com/Baelfire18/directUC/pull/73)
+- Add services sorting using drag and drop [`#72`](https://github.com/Baelfire18/directUC/pull/72)
+- Avoid accidentally burning your eyes when disabling auto dark mode [`#69`](https://github.com/Baelfire18/directUC/pull/69)
+- 📦✨ Add releases packed artifacts [`#66`](https://github.com/Baelfire18/directUC/pull/66)
+- Disable analytics for Firefox [`#63`](https://github.com/Baelfire18/directUC/pull/63)
+- Use titleCase false in react-ga [`#62`](https://github.com/Baelfire18/directUC/pull/62)
+- Refactor Analytics and add policies checkbox [`#61`](https://github.com/Baelfire18/directUC/pull/61)
+- feat: Add modifier click to open service in background new tab [`#59`](https://github.com/Baelfire18/directUC/pull/59)
+- Fix service name analytics [`#50`](https://github.com/Baelfire18/directUC/pull/50)
+- fix: Make analytics work again [`#49`](https://github.com/Baelfire18/directUC/pull/49)
+- Upgrade dependencies [`#41`](https://github.com/Baelfire18/directUC/pull/41)
+- Create dependabot.yml [`#35`](https://github.com/Baelfire18/directUC/pull/35)
+- Restore previous analytics setup [`#34`](https://github.com/Baelfire18/directUC/pull/34)
+- Add middleclick support for service button [`#33`](https://github.com/Baelfire18/directUC/pull/33)
+- Use node version 12 [`#30`](https://github.com/Baelfire18/directUC/pull/30)
+- Add Privacy Policy and Terms & Conditions [`#29`](https://github.com/Baelfire18/directUC/pull/29)
+- Get the version name to generate release changelog [`#28`](https://github.com/Baelfire18/directUC/pull/28)
+- Add Dark Mode [`#27`](https://github.com/Baelfire18/directUC/pull/27)
+- Add release action. Add develop branch checks [`#26`](https://github.com/Baelfire18/directUC/pull/26)
+- 📝 Changelog Templates [`#24`](https://github.com/Baelfire18/directUC/pull/24)
+- Add tests and initial github actions [`#23`](https://github.com/Baelfire18/directUC/pull/23)
+- Add missing reducers test [`#22`](https://github.com/Baelfire18/directUC/pull/22)
+- Add LICENSE [`#21`](https://github.com/Baelfire18/directUC/pull/21)
+- Add auto-changelog [`#20`](https://github.com/Baelfire18/directUC/pull/20)
+- Use package.json version [`#18`](https://github.com/Baelfire18/directUC/pull/18)
+- Add mailuc service [`#17`](https://github.com/Baelfire18/directUC/pull/17)
+- v1.0.0 - New version ✨ [`#14`](https://github.com/Baelfire18/directUC/pull/14)
+- fix: remove incognito key [`#13`](https://github.com/Baelfire18/directUC/pull/13)
+- fix: can't login directly to portal uc #4 [`#12`](https://github.com/Baelfire18/directUC/pull/12)
+- Email goes directly to gmail [`#11`](https://github.com/Baelfire18/directUC/pull/11)
+- Arreglar DCConfesión 9134 [`#9`](https://github.com/Baelfire18/directUC/pull/9)
+- Add suport to the Canvas platform. Small fixes. [`#3`](https://github.com/Baelfire18/directUC/pull/3)
+- Add LICENSE [`#5`](https://github.com/Baelfire18/directUC/pull/5)
+- Version 0.1.5 [`c0eed7d`](https://github.com/Baelfire18/directUC/commit/c0eed7dbaf9f517171e17238b8835cd0a4b91d66)
+- Major rewrite 2.0 [`337a1fd`](https://github.com/Baelfire18/directUC/commit/337a1fd709bc807d927ff4f6fded81f3fbc2d877)
+- Major Rewrite [`b3a5c83`](https://github.com/Baelfire18/directUC/commit/b3a5c8371e877b3520e509708cbd788df85775fc)
 
 --
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
+### [v4.2.7](https://github.com/Baelfire18/directUC/compare/v4.2.6...v4.2.7)
+
+- update changelog action v6 [`7387263`](https://github.com/Baelfire18/directUC/commit/738726310a3414b5b3ab0babb9f5399367bb81a8)
+
 ### [v4.2.6](https://github.com/Baelfire18/directUC/compare/v4.2.5...v4.2.6)
+
+> 14 November 2022
 
 - update changelog action v5 xd [`afaf8c6`](https://github.com/Baelfire18/directUC/commit/afaf8c6de0713d107f39bdaf334eeddffe6a58e3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
+### [v4.2.8](https://github.com/Baelfire18/directUC/compare/v4.2.7...v4.2.8)
+
+- update changelog action v7 [`c4c12e7`](https://github.com/Baelfire18/directUC/commit/c4c12e7daaef553272713e7821d20de74da35843)
+
 ### [v4.2.7](https://github.com/Baelfire18/directUC/compare/v4.2.6...v4.2.7)
+
+> 14 November 2022
 
 - update changelog action v6 [`7387263`](https://github.com/Baelfire18/directUC/commit/738726310a3414b5b3ab0babb9f5399367bb81a8)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "direct-uc",
   "description": "Extensión web que permite a alumnos y funcionarios de la Pontificia Universidad Católica de Chile el ingreso directo a diferentes servicios ofrecidos por esta.",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "repository": "git@github.com:wachunei/directUC.git",
   "author": "Pedro Pablo Aste Kompen <wachunei@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "direct-uc",
   "description": "Extensión web que permite a alumnos y funcionarios de la Pontificia Universidad Católica de Chile el ingreso directo a diferentes servicios ofrecidos por esta.",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "repository": "git@github.com:wachunei/directUC.git",
   "author": "Pedro Pablo Aste Kompen <wachunei@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "direct-uc",
   "description": "Extensión web que permite a alumnos y funcionarios de la Pontificia Universidad Católica de Chile el ingreso directo a diferentes servicios ofrecidos por esta.",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "repository": "git@github.com:wachunei/directUC.git",
   "author": "Pedro Pablo Aste Kompen <wachunei@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "direct-uc",
   "description": "Extensión web que permite a alumnos y funcionarios de la Pontificia Universidad Católica de Chile el ingreso directo a diferentes servicios ofrecidos por esta.",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "repository": "git@github.com:wachunei/directUC.git",
   "author": "Pedro Pablo Aste Kompen <wachunei@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "direct-uc",
   "description": "Extensión web que permite a alumnos y funcionarios de la Pontificia Universidad Católica de Chile el ingreso directo a diferentes servicios ofrecidos por esta.",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "repository": "git@github.com:wachunei/directUC.git",
   "author": "Pedro Pablo Aste Kompen <wachunei@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "direct-uc",
   "description": "Extensión web que permite a alumnos y funcionarios de la Pontificia Universidad Católica de Chile el ingreso directo a diferentes servicios ofrecidos por esta.",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "repository": "git@github.com:wachunei/directUC.git",
   "author": "Pedro Pablo Aste Kompen <wachunei@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "direct-uc",
   "description": "Extensión web que permite a alumnos y funcionarios de la Pontificia Universidad Católica de Chile el ingreso directo a diferentes servicios ofrecidos por esta.",
-  "version": "1.3.1",
+  "version": "4.2.0",
   "repository": "git@github.com:wachunei/directUC.git",
   "author": "Pedro Pablo Aste Kompen <wachunei@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "direct-uc",
   "description": "Extensión web que permite a alumnos y funcionarios de la Pontificia Universidad Católica de Chile el ingreso directo a diferentes servicios ofrecidos por esta.",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "repository": "git@github.com:wachunei/directUC.git",
   "author": "Pedro Pablo Aste Kompen <wachunei@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "direct-uc",
   "description": "Extensión web que permite a alumnos y funcionarios de la Pontificia Universidad Católica de Chile el ingreso directo a diferentes servicios ofrecidos por esta.",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "repository": "git@github.com:wachunei/directUC.git",
   "author": "Pedro Pablo Aste Kompen <wachunei@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Updated this 3 things:
- actions/checkout@v2 =>actions/checkout@v3
- actions/setup-node@v2-beta => actions/setup-node@v3
- actions/cache@v2 => actions/cache@v3
- [::set-output => $GITHUB_OUTPUT](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)